### PR TITLE
fix(redroid): scope remote credentials

### DIFF
--- a/internal/redroid/env.go
+++ b/internal/redroid/env.go
@@ -17,8 +17,9 @@ type Env struct {
 	SudoPass      string
 	CorrelationID string
 
-	SSHTarget string
-	SSHArgs   []string
+	SSHTarget   string
+	SSHArgs     []string
+	SSHPassword string
 
 	Context context.Context
 }
@@ -34,6 +35,7 @@ func Detect() Env {
 		CorrelationID: strings.TrimSpace(os.Getenv("AVDCTL_CORRELATION_ID")),
 		SSHTarget:     os.Getenv("AVDCTL_SSH_TARGET"),
 		SSHArgs:       strings.Fields(os.Getenv("AVDCTL_SSH_ARGS")),
+		SSHPassword:   os.Getenv("AVDCTL_SSH_PASSWORD"),
 		Context:       context.Background(),
 	}
 }

--- a/internal/redroid/ops.go
+++ b/internal/redroid/ops.go
@@ -451,7 +451,11 @@ func (m *manager) runOutputWithInput(stdin io.Reader, bin string, args ...string
 }
 
 func (m *manager) runRemote(args ...string) (string, error) {
-	out, errOut, err := remoteavdctl.RunOutput(m.context(), m.env.SSHTarget, m.env.SSHArgs, args)
+	remoteEnvironment := []string(nil)
+	if m.env.SudoPass != "" {
+		remoteEnvironment = []string{"AVDCTL_SUDO_PASSWORD=" + m.env.SudoPass}
+	}
+	out, errOut, err := remoteavdctl.RunOutputWithEnvironment(m.context(), m.env.SSHTarget, m.env.SSHArgs, m.env.SSHPassword, remoteEnvironment, args)
 	if err != nil {
 		return "", fmt.Errorf("remote avdctl %v failed: %w\n%s", args, err, strings.TrimSpace(errOut))
 	}

--- a/internal/remoteavdctl/client.go
+++ b/internal/remoteavdctl/client.go
@@ -11,10 +11,16 @@ import (
 	"github.com/forkbombeu/avdctl/internal/sshclient"
 )
 
-func remoteArgv(avdArgs []string) []string {
-	argv := make([]string, 0, len(avdArgs)+4)
+func remoteArgv(environment, avdArgs []string) []string {
+	argv := make([]string, 0, len(environment)+len(avdArgs)+4)
 	// Avoid recursive delegation on the remote side if these env vars are set there.
-	argv = append(argv, "env", "AVDCTL_SSH_TARGET=", "AVDCTL_SSH_ARGS=", "avdctl")
+	argv = append(argv, "env", "AVDCTL_SSH_TARGET=", "AVDCTL_SSH_ARGS=")
+	for _, entry := range environment {
+		if entry != "" {
+			argv = append(argv, entry)
+		}
+	}
+	argv = append(argv, "avdctl")
 	argv = append(argv, avdArgs...)
 	return argv
 }
@@ -30,13 +36,35 @@ func Run(
 	stderr io.Writer,
 	tty bool,
 ) error {
-	return sshclient.RunArgs(ctx, target, sshArgs, remoteArgv(avdArgs), stdin, stdout, stderr, tty)
+	return RunWithEnvironment(ctx, target, sshArgs, "", nil, avdArgs, stdin, stdout, stderr, tty)
+}
+
+// RunWithEnvironment delegates an avdctl command with connection-scoped SSH
+// authentication and remote-only environment values.
+func RunWithEnvironment(
+	ctx context.Context,
+	target string,
+	sshArgs []string,
+	sshPassword string,
+	environment []string,
+	avdArgs []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	tty bool,
+) error {
+	return sshclient.RunArgsWithPassword(ctx, target, sshArgs, sshPassword, remoteArgv(environment, avdArgs), stdin, stdout, stderr, tty)
 }
 
 // RunOutput delegates an avdctl command and captures stdout/stderr.
 func RunOutput(ctx context.Context, target string, sshArgs []string, avdArgs []string) (string, string, error) {
+	return RunOutputWithEnvironment(ctx, target, sshArgs, "", nil, avdArgs)
+}
+
+// RunOutputWithEnvironment delegates an avdctl command and captures output.
+func RunOutputWithEnvironment(ctx context.Context, target string, sshArgs []string, sshPassword string, environment, avdArgs []string) (string, string, error) {
 	var out bytes.Buffer
 	var errOut bytes.Buffer
-	err := Run(ctx, target, sshArgs, avdArgs, nil, &out, &errOut, false)
+	err := RunWithEnvironment(ctx, target, sshArgs, sshPassword, environment, avdArgs, nil, &out, &errOut, false)
 	return out.String(), errOut.String(), err
 }

--- a/internal/remoteavdctl/client_test.go
+++ b/internal/remoteavdctl/client_test.go
@@ -1,0 +1,16 @@
+package remoteavdctl
+
+import "testing"
+
+func TestRemoteArgvKeepsDelegationScoped(t *testing.T) {
+	argv := remoteArgv([]string{"AVDCTL_SUDO_PASSWORD=secret"}, []string{"run", "redroid"})
+	want := []string{"env", "AVDCTL_SSH_TARGET=", "AVDCTL_SSH_ARGS=", "AVDCTL_SUDO_PASSWORD=secret", "avdctl", "run", "redroid"}
+	if len(argv) != len(want) {
+		t.Fatalf("argv = %#v", argv)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, argv[i], want[i])
+		}
+	}
+}

--- a/internal/sshclient/client.go
+++ b/internal/sshclient/client.go
@@ -41,7 +41,21 @@ func Run(
 	stderr io.Writer,
 	tty bool,
 ) error {
-	client, err := dial(ctx, target, sshArgs)
+	return run(ctx, target, sshArgs, "", command, stdin, stdout, stderr, tty)
+}
+
+func run(
+	ctx context.Context,
+	target string,
+	sshArgs []string,
+	password string,
+	command string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	tty bool,
+) error {
+	client, err := dial(ctx, target, sshArgs, password)
 	if err != nil {
 		return err
 	}
@@ -80,7 +94,24 @@ func RunArgs(
 	stderr io.Writer,
 	tty bool,
 ) error {
-	return Run(ctx, target, sshArgs, shellWrap(shellJoin(argv)), stdin, stdout, stderr, tty)
+	return RunArgsWithPassword(ctx, target, sshArgs, "", argv, stdin, stdout, stderr, tty)
+}
+
+// RunArgsWithPassword executes argv with an explicit SSH password. The
+// password belongs to this connection only and is never written to process
+// environment.
+func RunArgsWithPassword(
+	ctx context.Context,
+	target string,
+	sshArgs []string,
+	password string,
+	argv []string,
+	stdin io.Reader,
+	stdout io.Writer,
+	stderr io.Writer,
+	tty bool,
+) error {
+	return run(ctx, target, sshArgs, password, shellWrap(shellJoin(argv)), stdin, stdout, stderr, tty)
 }
 
 func shellJoin(args []string) string {
@@ -95,7 +126,7 @@ func shellWrap(command string) string {
 	return "sh -lc " + shellQuote(command)
 }
 
-func dial(ctx context.Context, target string, sshArgs []string) (*ssh.Client, error) {
+func dial(ctx context.Context, target string, sshArgs []string, password string) (*ssh.Client, error) {
 	target = strings.TrimSpace(target)
 	if target == "" {
 		return nil, errors.New("empty ssh target")
@@ -124,7 +155,7 @@ func dial(ctx context.Context, target string, sshArgs []string) (*ssh.Client, er
 		port = parsed.Port
 	}
 
-	auth, err := authMethods(parsed.IdentityFiles)
+	auth, err := authMethods(parsed.IdentityFiles, password)
 	if err != nil {
 		return nil, err
 	}
@@ -288,10 +319,12 @@ func applyOpenSSHOption(out *parsedArgs, opt string) {
 	}
 }
 
-func authMethods(identityFiles []string) ([]ssh.AuthMethod, error) {
+func authMethods(identityFiles []string, password string) ([]ssh.AuthMethod, error) {
 	var methods []ssh.AuthMethod
 
-	if pass := os.Getenv("AVDCTL_SSH_PASSWORD"); pass != "" {
+	if pass := strings.TrimSpace(password); pass != "" {
+		methods = append(methods, ssh.Password(pass))
+	} else if pass := os.Getenv("AVDCTL_SSH_PASSWORD"); pass != "" {
 		methods = append(methods, ssh.Password(pass))
 	}
 

--- a/pkg/redroidmanager/manager.go
+++ b/pkg/redroidmanager/manager.go
@@ -25,8 +25,9 @@ type Environment struct {
 	Sudo       bool
 	SudoPass   string
 
-	SSHTarget string
-	SSHArgs   []string
+	SSHTarget   string
+	SSHArgs     []string
+	SSHPassword string
 
 	CorrelationID string
 	Context       context.Context
@@ -75,6 +76,7 @@ func NewWithEnv(env Environment) *Manager {
 			CorrelationID: env.CorrelationID,
 			SSHTarget:     env.SSHTarget,
 			SSHArgs:       env.SSHArgs,
+			SSHPassword:   env.SSHPassword,
 			Context:       ctx,
 		},
 	}

--- a/pkg/redroidmanager/manager_test.go
+++ b/pkg/redroidmanager/manager_test.go
@@ -7,15 +7,16 @@ import (
 
 func TestNewWithEnvMapsEnvironment(t *testing.T) {
 	mgr := NewWithEnv(Environment{
-		DockerHost: "unix:///var/run/docker.sock",
-		ADBBin:     "adb-custom",
-		TarBin:     "tar-custom",
-		SudoBin:    "sudo-custom",
-		Sudo:       true,
-		SudoPass:   "secret",
-		SSHTarget:  "user@host",
-		SSHArgs:    []string{"-i", "key"},
-		Context:    context.Background(),
+		DockerHost:  "unix:///var/run/docker.sock",
+		ADBBin:      "adb-custom",
+		TarBin:      "tar-custom",
+		SudoBin:     "sudo-custom",
+		Sudo:        true,
+		SudoPass:    "secret",
+		SSHTarget:   "user@host",
+		SSHArgs:     []string{"-i", "key"},
+		SSHPassword: "ssh-secret",
+		Context:     context.Background(),
 	})
 
 	if mgr.env.ADBBin != "adb-custom" {
@@ -29,5 +30,8 @@ func TestNewWithEnvMapsEnvironment(t *testing.T) {
 	}
 	if len(mgr.env.SSHArgs) != 2 {
 		t.Fatalf("SSHArgs = %#v", mgr.env.SSHArgs)
+	}
+	if mgr.env.SSHPassword != "ssh-secret" {
+		t.Fatalf("SSHPassword was not mapped")
 	}
 }


### PR DESCRIPTION
reason:
Keep SSH and sudo credentials bound to the selected Redroid connection instead of relying on process environment.

prompt:
Fix remote Redroid archive operations without global device state.