### PR TITLE
fix(ssh): use trusted host key algorithms

### DIFF
--- a/internal/sshclient/client.go
+++ b/internal/sshclient/client.go
@@ -176,6 +176,33 @@ func dial(ctx context.Context, target string, sshArgs []string, password string)
 	}
 
 	address := net.JoinHostPort(host, strconv.Itoa(port))
+	client, err := dialClient(ctx, address, config)
+	if err == nil {
+		return client, nil
+	}
+
+	var keyErr *knownhosts.KeyError
+	if !errors.As(err, &keyErr) || len(keyErr.Want) == 0 {
+		return nil, err
+	}
+
+	algorithms := knownHostKeyAlgorithms(keyErr.Want)
+	if len(algorithms) == 0 {
+		return nil, err
+	}
+	for _, algorithm := range algorithms {
+		retryConfig := *config
+		retryConfig.HostKeyAlgorithms = []string{algorithm}
+		client, retryErr := dialClient(ctx, address, &retryConfig)
+		if retryErr == nil {
+			return client, nil
+		}
+		err = retryErr
+	}
+	return nil, err
+}
+
+func dialClient(ctx context.Context, address string, config *ssh.ClientConfig) (*ssh.Client, error) {
 	dialer := &net.Dialer{Timeout: 30 * time.Second}
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
@@ -188,6 +215,28 @@ func dial(ctx context.Context, target string, sshArgs []string, password string)
 		return nil, fmt.Errorf("ssh handshake %s: %w", address, err)
 	}
 	return ssh.NewClient(cConn, chans, reqs), nil
+}
+
+// knownHostKeyAlgorithms limits a retry to algorithms already trusted for the
+// destination. This lets a host with multiple key types use a known key even
+// when Go's default negotiation selects an unlisted key type first.
+func knownHostKeyAlgorithms(keys []knownhosts.KnownKey) []string {
+	algorithms := make([]string, 0, len(keys))
+	seen := make(map[string]struct{})
+	for _, knownKey := range keys {
+		keyAlgorithms := []string{knownKey.Key.Type()}
+		if knownKey.Key.Type() == ssh.KeyAlgoRSA {
+			keyAlgorithms = []string{ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSA}
+		}
+		for _, algorithm := range keyAlgorithms {
+			if _, ok := seen[algorithm]; ok {
+				continue
+			}
+			seen[algorithm] = struct{}{}
+			algorithms = append(algorithms, algorithm)
+		}
+	}
+	return algorithms
 }
 
 func runSession(ctx context.Context, client *ssh.Client, session *ssh.Session, command string) error {

--- a/internal/sshclient/client_test.go
+++ b/internal/sshclient/client_test.go
@@ -1,6 +1,21 @@
 package sshclient
 
-import "testing"
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
 
 func TestSplitTarget(t *testing.T) {
 	host, port, user, err := splitTarget("alice@example.com:2222")
@@ -36,3 +51,110 @@ func TestParseArgs(t *testing.T) {
 		t.Fatalf("missing known_hosts files: %#v", got.KnownHostsFiles)
 	}
 }
+
+func TestKnownHostKeyAlgorithmsUsesTrustedKeyTypes(t *testing.T) {
+	keys := []knownhosts.KnownKey{
+		{Key: testPublicKey{keyType: ssh.KeyAlgoED25519}},
+		{Key: testPublicKey{keyType: ssh.KeyAlgoRSA}},
+		{Key: testPublicKey{keyType: ssh.KeyAlgoED25519}},
+	}
+
+	got := knownHostKeyAlgorithms(keys)
+	want := []string{ssh.KeyAlgoED25519, ssh.KeyAlgoRSASHA512, ssh.KeyAlgoRSASHA256, ssh.KeyAlgoRSA}
+	if len(got) != len(want) {
+		t.Fatalf("algorithm count = %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("algorithm[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDialRetriesWithTrustedHostKeyAlgorithm(t *testing.T) {
+	_, edPrivate, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	edSigner, err := ssh.NewSignerFromKey(edPrivate)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecdsaPrivate, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecdsaSigner, err := ssh.NewSignerFromKey(ecdsaPrivate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	serverConfig := &ssh.ServerConfig{
+		PasswordCallback: func(ssh.ConnMetadata, []byte) (*ssh.Permissions, error) {
+			return nil, nil
+		},
+	}
+	serverConfig.AddHostKey(ecdsaSigner)
+	serverConfig.AddHostKey(edSigner)
+	accepted := make(chan struct{}, 2)
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			accepted <- struct{}{}
+			go func() {
+				serverConn, channels, requests, handshakeErr := ssh.NewServerConn(conn, serverConfig)
+				if handshakeErr != nil {
+					return
+				}
+				defer serverConn.Close()
+				go ssh.DiscardRequests(requests)
+				for channel := range channels {
+					_ = channel.Reject(ssh.UnknownChannelType, "not used by this test")
+				}
+			}()
+		}
+	}()
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	knownHostsPath := filepath.Join(t.TempDir(), "known_hosts")
+	knownHost := fmt.Sprintf("[%s]:%s %s", host, port, ssh.MarshalAuthorizedKey(edSigner.PublicKey()))
+	if err := os.WriteFile(knownHostsPath, []byte(knownHost), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := dial(context.Background(), "test@"+listener.Addr().String(), []string{
+		"-o", "UserKnownHostsFile=" + knownHostsPath,
+	}, "password")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	for attempt := 0; attempt < 2; attempt++ {
+		select {
+		case <-accepted:
+		case <-time.After(time.Second):
+			t.Fatalf("SSH attempts = %d, want 2", attempt)
+		}
+	}
+}
+
+type testPublicKey struct {
+	keyType string
+}
+
+func (key testPublicKey) Type() string                    { return key.keyType }
+func (testPublicKey) Marshal() []byte                     { return nil }
+func (testPublicKey) Verify([]byte, *ssh.Signature) error { return nil }


### PR DESCRIPTION
reason:
Retry strict SSH verification with host-key algorithms already listed for the destination when the default negotiation picks another type.

prompt:
Allow avdctl SSH delegation when a server exposes multiple host-key types.